### PR TITLE
Use shorter command name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ P.S. Inspired by [Visual Studio Code](https://code.visualstudio.com/) goto line 
 ## Usage ##
 Call it from `minibuffer` directly, 
 ```
-M-x goto-line-preview-goto-line
+M-x goto-line-preview
 ```
 Or you can just bind to any key you want.
 ```el
-(define-key global-map (kbd "M-g") #'goto-line-preview-goto-line)
+(define-key global-map (kbd "M-g") #'goto-line-preview)
 ```
 
 

--- a/goto-line-preview.el
+++ b/goto-line-preview.el
@@ -73,7 +73,7 @@ LINE-NUM : Target line number to navigate to."
 
 
 ;;;###autoload
-(defun goto-line-preview-goto-line ()
+(defun goto-line-preview ()
   "Preview goto line.
 LINE-NUM : Target line number to navigate to."
   (interactive)
@@ -87,6 +87,8 @@ LINE-NUM : Target line number to navigate to."
       (unless jumped
         (set-window-point window window-point)))))
 
+;;;###autoload
+(define-obsolete-function-alias 'goto-line-preview-goto-line 'goto-line-preview)
 
 (defun goto-line-preview-minibuffer-setup ()
   "Locally set up preview hooks for this minibuffer command."


### PR DESCRIPTION
Given that this package really just provides one command, let's use the shorter name for it. :-)