### PR TITLE
Don't suggest rebinding M-g

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Call it from `minibuffer` directly,
 ```
 M-x goto-line-preview
 ```
-Or you can just bind to any key you want.
+Or you can bind it globally to replace `goto-line`:
 ```el
-(define-key global-map (kbd "M-g") #'goto-line-preview)
+(global-set-key [remap goto-line] 'goto-line-preview)
 ```
 
 


### PR DESCRIPTION
Quick doc fix: `M-g` is a prefix for several commands. Better to instead show how to replace `goto-line` on its default binding of `M-g M-g`.