### PR TITLE
Don't force recentering, and avoid use of with-no-warnings

### DIFF
--- a/goto-line-preview.el
+++ b/goto-line-preview.el
@@ -67,9 +67,8 @@
 LINE-NUM : Target line number to navigate to."
   (save-selected-window
     (switch-to-buffer goto-line-preview-prev-buffer)
-    (with-no-warnings
-      (goto-line line-num))
-    (call-interactively #'recenter)))
+    (goto-char (point-min))
+    (forward-line (1- line-num))))
 
 
 ;;;###autoload


### PR DESCRIPTION
- Recentering means the window moves even if the command is cancelled.  In reality, Emacs behaves reasonably even when without calling recenter, and its behaviour is configurable, so we shouldn't hard-code recentering here.
- Use the recommended non-interactive alternative to goto-line, so that with-no-warnings is unnecessary