### PR TITLE
Add before/after hooks for goto-line-preview

### DIFF
--- a/goto-line-preview.el
+++ b/goto-line-preview.el
@@ -47,6 +47,16 @@
 (defvar goto-line-preview-prev-line-num nil
   "Record down the previous line number before we do `goto-line-preview-goto-line' command.")
 
+(defcustom goto-line-preview-before-hook nil
+  "Hooks run before `goto-line-preview' is run."
+  :group 'goto-line-preview
+  :type 'hook)
+
+(defcustom goto-line-preview-after-hook nil
+  "Hooks run after `goto-line-preview' is run."
+  :group 'goto-line-preview
+  :type 'hook)
+
 
 (defun goto-line-preview-do-preview ()
   "Do the goto line preview action."
@@ -79,13 +89,15 @@ LINE-NUM : Target line number to navigate to."
   (let ((window (selected-window))
         (window-point (window-point))
         jumped)
+    (run-hooks 'goto-line-preview-before-hook)
     (unwind-protect
         (let ((goto-line-preview-prev-buffer (buffer-name))
               (goto-line-preview-prev-line-num (line-number-at-pos)))
           (setq jumped (read-number "Goto line: ")))
       (if jumped
           (call-interactively #'recenter)
-        (set-window-point window window-point)))))
+        (set-window-point window window-point))
+      (run-hooks 'goto-line-preview-after-hook))))
 
 ;;;###autoload
 (define-obsolete-function-alias 'goto-line-preview-goto-line 'goto-line-preview)


### PR DESCRIPTION
These hooks let the user set up something like:

```emacs-lisp
(setq goto-line-preview-before-hook (lambda () (display-line-numbers-mode))
      goto-line-preview-after-hook (lambda () (display-line-numbers-mode -1)))
````

This is an attempt at fixing https://github.com/jcs090218/goto-line-preview/issues/2

I hope @purcell and @waymondo can share their opinions on this. Happy to fix anything that doesn't work as expected, of course.


