### PR TITLE
Add missing parameter to define-obsolete-function-alias

### DIFF
--- a/goto-line-preview.el
+++ b/goto-line-preview.el
@@ -104,7 +104,7 @@
     (goto-line-preview)))
 
 ;;;###autoload
-(define-obsolete-function-alias 'goto-line-preview-goto-line 'goto-line-preview)
+(define-obsolete-function-alias 'goto-line-preview-goto-line 'goto-line-preview "0.1.1")
 
 (defun goto-line-preview--minibuffer-setup ()
   "Locally set up preview hooks for this minibuffer command."


### PR DESCRIPTION
The signature of the function define-obsolete-function-alias has changed in Emacs 28.0.50 from two required arguments to three (adding WHEN).