### PR TITLE
Push mark before jumping

### DIFF
--- a/goto-line-preview.el
+++ b/goto-line-preview.el
@@ -92,7 +92,10 @@
                       (if goto-line-preview--relative-p
                           "Goto line relative: "
                         "Goto line: ")))
-      (unless jumped
+      (if jumped
+          (with-current-buffer (window-buffer goto-line-preview--prev-window)
+            (unless (region-active-p)
+              (push-mark window-point)))
         (set-window-point goto-line-preview--prev-window window-point))
       (run-hooks 'goto-line-preview-after-hook))))
 


### PR DESCRIPTION
To behave more like `goto-line`, the current point should be pushed onto the buffer's mark ring before jumping to the new line, unless the command was cancelled.