### PR TITLE
show min/max line number in minibuffer

### DIFF
--- a/goto-line-preview.el
+++ b/goto-line-preview.el
@@ -88,10 +88,13 @@
     (run-hooks 'goto-line-preview-before-hook)
     (unwind-protect
         (setq jumped (read-number
-		      (let ((lines (count-lines (point-min) (point-max))))
-			   (if goto-line-preview--relative-p
-			       (format "Goto line relative[%d - %d]: " (max 0 (min 1 lines)) lines)
-			     (format "Goto line[%d - %d]: " (max 0 (min 1 lines)) lines)))))
+		      (let ((lines (line-number-at-pos (point-max))))
+			(format (if goto-line-preview--relative-p
+				    "[%d] Goto line relative: (%d to %d) "
+				  "[%d] Goto line: (%d to %d) ")
+				goto-line-preview--prev-line-num
+				(max 0 (min 1 lines))
+				lines))))
       (if jumped
           (with-current-buffer (window-buffer goto-line-preview--prev-window)
             (unless (region-active-p) (push-mark window-point)))

--- a/goto-line-preview.el
+++ b/goto-line-preview.el
@@ -87,9 +87,11 @@
         jumped)
     (run-hooks 'goto-line-preview-before-hook)
     (unwind-protect
-        (setq jumped (read-number (if goto-line-preview--relative-p
-                                      "Goto line relative: "
-                                    "Goto line: ")))
+        (setq jumped (read-number
+		      (let ((lines (count-lines (point-min) (point-max))))
+			   (if goto-line-preview--relative-p
+			       (format "Goto line relative[%d - %d]: " (max 0 (min 1 lines)) lines)
+			     (format "Goto line[%d - %d]: " (max 0 (min 1 lines)) lines)))))
       (if jumped
           (with-current-buffer (window-buffer goto-line-preview--prev-window)
             (unless (region-active-p) (push-mark window-point)))


### PR DESCRIPTION
VScode can show the min/max line number of the file when goto line, it's a useful feature for users who want to know the total line number when use goto-line command, So I suggest to add the feature into `goto-line-preview`.

![image](https://user-images.githubusercontent.com/29608850/211612102-ebf53fee-1dde-4739-81ec-af7753cc3d82.png)

test with buffer which has contents

![image](https://user-images.githubusercontent.com/29608850/211611096-efd1558e-2b91-4792-91c9-d9e46d63b7c2.png)

test with empty buffer

![image](https://user-images.githubusercontent.com/29608850/211611310-2948afd7-96a7-4173-bd95-e49a765d7173.png)
