### PR TITLE
show lines hidden by overlays when inside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 * Implement highlight a duration when preview line changed ([#16](../../pull/16))
 * fix: Don't restrict to command only ([`e11a1e7`](../../commit/e11a1e7bfff5240e44d71d2ff8fae2d5bcbda784))
+* Show lines made invisible (e.g. through folding) during line preview
 
 ## 0.1.0
 > Released Sep 26, 2020


### PR DESCRIPTION
If preview lines that have been folded (in my case using yafolding), the actual line is not visible.
This code makes the invisible parts of the file visible during the preview, restoring the visibility in the end.
If the goto line target is within an invisible section, this sections overlay will be removed, which, in my case, will make the lines unfold.

The code only applies, if the point is within an overlay that has its property 'invisible set to true. Else there is no change in behavior.